### PR TITLE
希望发布到npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cordova-plugin-qqsdk",
+  "version": "1.0.0",
+  "description": "codrova/phonegap wrapper for qq sdk",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/iVanPan/Cordova_QQ.git"
+  },
+  "keywords": [
+    "cordova",
+    "phonegap",
+    "plugin",
+    "qqsdk",
+    "qq",
+    "tercent",
+    "login",
+    "share"
+  ],
+  "author": "https://github.com/iVanPan",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/21paradox/Cordova_QQ/issues"
+  },
+  "homepage": "https://github.com/21paradox/Cordova_QQ#readme"
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "https://github.com/iVanPan",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/21paradox/Cordova_QQ/issues"
+    "url": "https://github.com/iVanPan/Cordova_QQ/issues"
   },
-  "homepage": "https://github.com/21paradox/Cordova_QQ#readme"
+  "homepage": "https://github.com/iVanPan/Cordova_QQ"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-qqsdk",
-  "version": "1.0.0",
+  "version": "0.3.6",
   "description": "codrova/phonegap wrapper for qq sdk",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,15 @@
     "type": "git",
     "url": "git+https://github.com/iVanPan/Cordova_QQ.git"
   },
+  "cordova": {
+    "id": "cordova-plugin-qqsdk",
+    "platforms": [
+      "android",
+      "ios"
+    ]
+  },
   "keywords": [
+    "ecosystem:cordova",
     "cordova",
     "phonegap",
     "plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
   xmlns:android="http://schemas.android.com/apk/res/android"
-  id="org.zy.yuancheng.qq"
+  id="cordova-plugin-qqsdk"
   version="0.3.6">
 
   <name>YCQQ</name>


### PR DESCRIPTION
目前 cordova/phonegap 的包管理都已经迁移npm了

链接：
http://plugins.cordova.io/#/
https://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html
http://plugins.cordova.io/npm/index.html

我还修改了一下 package名字为 "cordova-plugin-qqsdk"

希望merge , 并且注册和发布到npm

下面是发布到npm的链接
https://docs.npmjs.com/getting-started/publishing-npm-packages
