### PR TITLE
change: return raw error info for debug.

### DIFF
--- a/src/android/YCQQ.java
+++ b/src/android/YCQQ.java
@@ -28,13 +28,13 @@ public class YCQQ extends CordovaPlugin {
     private String APP_ID;
     private static final String QQ_APP_ID = "qq_app_id";
     private static final String QQ_CANCEL_BY_USER = "cancelled by user";
-    private static final String QQ_SHARE_ERROR = "error happened when sharing";
-    private static final String QQ_LOGIN_ERROR = "error happened when logging";
+    // private static final String QQ_SHARE_ERROR = "error happened when sharing";
+    // private static final String QQ_LOGIN_ERROR = "error happened when logging";
     private static final String QQ_PARAM_ERROR = "param incorrect";
     private static final String QQ_RESPONSE_ERROR = "QQ response is error";
-    private static final String QZONE_SHARE_ERROR = "QZone share is error";
+    // private static final String QZONE_SHARE_ERROR = "QZone share is error";
     private static final String QZONE_SHARE_CANCEL = "QZone share is cancelled";
-    private static final String QQFAVORITES_ERROR = "QQ Favorites is error";
+    // private static final String QQFAVORITES_ERROR = "QQ Favorites is error";
     private static final String QQFAVORITES_CANCEL = "QQ Favorites is cancelled";
     private static final String QQ_Client_NOT_INSYALLED_ERROR = "QQ client is not installed";
     private static final String TITLIE_IS_EMPTY = "share title is empty";
@@ -303,8 +303,9 @@ public class YCQQ extends CordovaPlugin {
 
         @Override
         public void onError(UiError uiError) {
+            String msg = String.format("[%1$d]%2$s: %3$s", e.errorCode, e.errorMessage, e.errorDetail);
             YCQQ.this.webView.sendPluginResult(new PluginResult(
-                    PluginResult.Status.ERROR, QQ_LOGIN_ERROR), currentCallbackContext.getCallbackId());
+                    PluginResult.Status.ERROR, msg), currentCallbackContext.getCallbackId());
         }
 
         @Override
@@ -331,8 +332,9 @@ public class YCQQ extends CordovaPlugin {
 
         @Override
         public void onError(UiError e) {
+            String msg = String.format("[%1$d]%2$s: %3$s", e.errorCode, e.errorMessage, e.errorDetail);
             YCQQ.this.webView.sendPluginResult(new PluginResult(
-                    PluginResult.Status.ERROR, QQ_SHARE_ERROR), currentCallbackContext.getCallbackId());
+                    PluginResult.Status.ERROR, msg), currentCallbackContext.getCallbackId());
         }
 
     };
@@ -349,8 +351,9 @@ public class YCQQ extends CordovaPlugin {
 
         @Override
         public void onError(UiError e) {
+            String msg = String.format("[%1$d]%2$s: %3$s", e.errorCode, e.errorMessage, e.errorDetail);
             YCQQ.this.webView.sendPluginResult(new PluginResult(
-                    PluginResult.Status.ERROR, QZONE_SHARE_ERROR), currentCallbackContext.getCallbackId());
+                    PluginResult.Status.ERROR, msg), currentCallbackContext.getCallbackId());
         }
 
         @Override
@@ -378,8 +381,9 @@ public class YCQQ extends CordovaPlugin {
 
         @Override
         public void onError(UiError e) {
+            String msg = String.format("[%1$d]%2$s: %3$s", e.errorCode, e.errorMessage, e.errorDetail);
             YCQQ.this.webView.sendPluginResult(new PluginResult(
-                    PluginResult.Status.ERROR, QQFAVORITES_ERROR), currentCallbackContext.getCallbackId());
+                    PluginResult.Status.ERROR, msg), currentCallbackContext.getCallbackId());
         }
     };
 


### PR DESCRIPTION
之前由于传入的参数不对，导致QQ分享失败。组件在第一次失败时提示：`error happended when sharing`，而后再点全是`canceled by user`，最关键一不注意以为分享失败是由于用户取消了。

建议对外展示原始的error信息，如此Pull Request，修改之后的返回为：`[-6]传入参数有误!: null`
